### PR TITLE
ci(vscode): downgrade angular language service

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 		"vscode": {
 			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [
-				"angular.ng-template",
+				"angular.ng-template@14.1.0",
 				"dbaeumer.vscode-eslint",
 				"eamodio.gitlens"
 			]


### PR DESCRIPTION
Downgrade extension to support template 'go to definition'
https://github.com/angular/vscode-ng-language-service/issues/1753#issuecomment-1252471732